### PR TITLE
Add dark mode toggle

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -371,3 +371,43 @@ body { background: #f5f6fa; }
     display: none !important;
   }
 }
+
+/* === Dark mode === */
+body.dark-mode {
+  background: #222;
+  color: #eee;
+}
+body.dark-mode .ms-header {
+  background: #333;
+  border-bottom-color: #444;
+}
+body.dark-mode .ms-nav-link,
+body.dark-mode .ms-header-link,
+body.dark-mode .ms-logo-text {
+  color: #eee;
+}
+body.dark-mode .ms-header-icon {
+  background: #444;
+  color: #eee;
+}
+body.dark-mode .ms-header-icon:hover {
+  background: #555;
+}
+body.dark-mode .ms-searchbar {
+  background: #333;
+}
+body.dark-mode .ms-search-input {
+  color: #eee;
+}
+body.dark-mode .ms-mobile-menu {
+  background: #2b2b2b;
+}
+body.dark-mode .ms-mobile-menu-link {
+  color: #eee;
+  border-bottom-color: #444;
+}
+body.dark-mode .ms-mobile-menu-link:hover,
+body.dark-mode .ms-mobile-menu-link:focus {
+  background: #444;
+  color: #fff;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,1 +1,45 @@
-// This file is intentionally left blank.
+// Mobile menu toggle & theme switcher
+
+document.addEventListener('DOMContentLoaded', function () {
+  const menuBtn = document.getElementById('msMenuBtn');
+  const menu = document.getElementById('msMobileMenu');
+  const overlay = document.getElementById('msMobileMenuOverlay');
+  const closeBtn = document.getElementById('msMenuCloseBtn');
+
+  function openMenu() {
+    menu.classList.add('open');
+    overlay.classList.add('show');
+    document.body.style.overflow = 'hidden';
+  }
+  function closeMenu() {
+    menu.classList.remove('open');
+    overlay.classList.remove('show');
+    document.body.style.overflow = '';
+  }
+
+  menuBtn && menuBtn.addEventListener('click', openMenu);
+  closeBtn && closeBtn.addEventListener('click', closeMenu);
+  overlay && overlay.addEventListener('click', closeMenu);
+
+  // Theme toggle
+  const themeToggle = document.getElementById('themeToggle');
+  const icon = themeToggle ? themeToggle.querySelector('i') : null;
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const savedTheme = localStorage.getItem('ms-theme');
+  const enableDark = savedTheme === 'dark' || (prefersDark && savedTheme !== 'light');
+  if (enableDark) {
+    document.body.classList.add('dark-mode');
+    if (icon) icon.classList.replace('bi-moon', 'bi-sun');
+  }
+  themeToggle && themeToggle.addEventListener('click', () => {
+    const isDark = document.body.classList.toggle('dark-mode');
+    if (icon) {
+      if (isDark) {
+        icon.classList.replace('bi-moon', 'bi-sun');
+      } else {
+        icon.classList.replace('bi-sun', 'bi-moon');
+      }
+    }
+    localStorage.setItem('ms-theme', isDark ? 'dark' : 'light');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
           </form>
           <a href="#" class="ms-header-icon"><i class="bi bi-geo-alt"></i></a>
           <a href="#" class="ms-header-icon"><i class="bi bi-cart"></i></a>
+          <button id="themeToggle" class="ms-header-icon btn" aria-label="Chuyển giao diện">
+            <i class="bi bi-moon"></i>
+          </button>
           <a href="#" class="ms-header-link d-none d-md-inline">Đăng nhập</a>
           <a href="#" class="ms-header-btn d-none d-md-inline">Đăng ký</a>
           <!-- Hamburger menu on mobile -->
@@ -427,25 +430,5 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="assets/js/main.js"></script>
-    <script>
-      // Mobile menu toggle
-      const menuBtn = document.getElementById('msMenuBtn');
-      const menu = document.getElementById('msMobileMenu');
-      const overlay = document.getElementById('msMobileMenuOverlay');
-      const closeBtn = document.getElementById('msMenuCloseBtn');
-      function openMenu() {
-        menu.classList.add('open');
-        overlay.classList.add('show');
-        document.body.style.overflow = 'hidden';
-      }
-      function closeMenu() {
-        menu.classList.remove('open');
-        overlay.classList.remove('show');
-        document.body.style.overflow = '';
-      }
-      menuBtn && menuBtn.addEventListener('click', openMenu);
-      closeBtn && closeBtn.addEventListener('click', closeMenu);
-      overlay && overlay.addEventListener('click', closeMenu);
-    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add theme toggle button to header
- move scripts to main.js and include dark mode logic
- style dark mode in CSS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683ff3e08548832a8b1e323cc9f5df8e